### PR TITLE
fixed gallery size breaks

### DIFF
--- a/client/src/components/gallery_slide/GallerySlide.tsx
+++ b/client/src/components/gallery_slide/GallerySlide.tsx
@@ -42,6 +42,7 @@ const UnstyledGallerySlide: FunctionComponent<GallerySlideProps> = ({
   if (!viewer?.galleries || !showGallery) {
     return (
       <Box
+        mt={9.2}
         ml={10}
         sx={{
           width: '54rem',
@@ -92,6 +93,7 @@ const UnstyledGallerySlide: FunctionComponent<GallerySlideProps> = ({
 
   return (
     <Box
+      mt={9.2}
       ml={10}
       sx={{
         width: '56rem',

--- a/client/src/components/home_content/HomeContent.tsx
+++ b/client/src/components/home_content/HomeContent.tsx
@@ -202,7 +202,7 @@ const UnstyledHomeContent: FunctionComponent<HomeContentProps> = ({
 
           {/* Galleries Slide Show */}
           {!isMobile && (
-            <Box mt={9.2}>
+            <Box display='contents'>
               <GallerySlide />
             </Box>
           )}

--- a/client/src/components/thumbnail/Thumbnail.tsx
+++ b/client/src/components/thumbnail/Thumbnail.tsx
@@ -61,7 +61,7 @@ const UnstyledThumbnail: FunctionComponent<ThumbnailProps> = ({
 
   return (
     <Box className={className} display="flex" justifyContent="center" mb={6}>
-      <Box display="flex">
+      <Box display="flex" width="70rem">
         {/* Only show the arrow button when the number of images over numOfThumbnail */}
         {galleryImages.length > numOfThumbnail && (
           <ChevronLeftIcon
@@ -70,7 +70,13 @@ const UnstyledThumbnail: FunctionComponent<ThumbnailProps> = ({
           />
         )}
 
-        <Box display='flex' justifyContent='flex-start' px={2} width='70rem' className="thumbnail-box">
+        <Box
+          display="flex"
+          justifyContent="flex-start"
+          px={2}
+          width="100%"
+          className="thumbnail-box"
+        >
           {map(
             galleryImages.slice(
               page * numOfThumbnail,


### PR DESCRIPTION
## Fixed homepage gallery size breaks
<img width="1049" alt="Screen Shot 2021-11-12 at 5 05 47 AM" src="https://user-images.githubusercontent.com/47313362/141454435-020fca94-33ea-4b16-9b94-90452bcabe10.png">

<img width="1267" alt="Screen Shot 2021-11-12 at 5 41 46 AM" src="https://user-images.githubusercontent.com/47313362/141454440-9fa622bf-73c2-4a6b-aba4-c731f13384ef.png">
>


## before gallery detail
<img width="1126" alt="Screen Shot 2021-11-12 at 5 08 12 AM" src="https://user-images.githubusercontent.com/47313362/141454516-ce11bdf1-caa0-419d-a282-6038463c5408.png">

## after fixed gallery detail thumbnail size
<img width="1432" alt="Screen Shot 2021-11-12 at 5 42 32 AM" src="https://user-images.githubusercontent.com/47313362/141454602-0ba4e254-d535-4119-b829-7d5ec5323d88.png">


