### PR TITLE
fix schedule cards

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -92,61 +92,63 @@ const App: FunctionComponent = () => {
             {!isAdminRoute && <Navigation />}
 
             <Switch>
-              {/* ADMIN ROUTE */}
-              {/* This route should be guarded for admin access only!! */}
-              <Route path="/admin">
-                <Admin />
-              </Route>
-
-              <Box style={{ paddingBottom: '15rem' }}>
-                <Route exact path="/">
-                  <Home />
+              <>
+                {/* ADMIN ROUTE */}
+                {/* This route should be guarded for admin access only!! */}
+                <Route path="/admin">
+                  <Admin />
                 </Route>
 
-                {/* About section */}
-                <Route
-                  path={['/overview', '/president', '/contact']}
-                  component={About}
-                />
+                <Box style={{ paddingBottom: '15rem' }}>
+                  <Route exact path="/">
+                    <Home />
+                  </Route>
 
-                {/* This might be broken into per season */}
-                <Route path="/league/:id">
-                  <League />
-                </Route>
+                  {/* About section */}
+                  <Route
+                    path={['/overview', '/president', '/contact']}
+                    component={About}
+                  />
 
-                {/* This might be broken into per season */}
-                <Route path="/teams/:id">
-                  <Team />
-                </Route>
+                  {/* This might be broken into per season */}
+                  <Route path="/league/:id">
+                    <League />
+                  </Route>
 
-                <Route exact path="/dashboard">
-                  <Dashboard />
-                </Route>
+                  {/* This might be broken into per season */}
+                  <Route path="/teams/:id">
+                    <Team />
+                  </Route>
 
-                <Route path="/announcement/:id?">
-                  <Announcements />
-                </Route>
+                  <Route exact path="/dashboard">
+                    <Dashboard />
+                  </Route>
 
-                <Route path="/login">
-                  <Login />
-                </Route>
+                  <Route path="/announcement/:id?">
+                    <Announcements />
+                  </Route>
 
-                <Route path="/create">
-                  <Create />
-                </Route>
+                  <Route path="/login">
+                    <Login />
+                  </Route>
 
-                <Route path="/registerteam">
-                  <RegisterTeam />
-                </Route>
+                  <Route path="/create">
+                    <Create />
+                  </Route>
 
-                <Route exact path="/gallery">
-                  <Media />
-                </Route>
+                  <Route path="/registerteam">
+                    <RegisterTeam />
+                  </Route>
 
-                <Route path="/gallery/:id">
-                  <GalleryDetail />
-                </Route>
-              </Box>
+                  <Route exact path="/gallery">
+                    <Media />
+                  </Route>
+
+                  <Route path="/gallery/:id">
+                    <GalleryDetail />
+                  </Route>
+                </Box>
+              </>
             </Switch>
 
             {!isAdminRoute && <Footer />}

--- a/client/src/admin/Admin.tsx
+++ b/client/src/admin/Admin.tsx
@@ -131,43 +131,45 @@ export const Admin: React.FC = () => {
         <Toolbar />
 
         <Switch>
-          <Route exact path={path}>
-            <h3>Please select a menu.</h3>
-          </Route>
+          <>
+            <Route exact path={path}>
+              <h3>Please select a menu.</h3>
+            </Route>
 
-          {/* Render page for /invite */}
-          <Route path={`${url}/invite`}>
-            <Users />
-          </Route>
+            {/* Render page for /invite */}
+            <Route path={`${url}/invite`}>
+              <Users />
+            </Route>
 
-          {/* Render page for /league */}
-          <Route exact path={`${url}/league`}>
-            <Leagues />
-          </Route>
+            {/* Render page for /league */}
+            <Route exact path={`${url}/league`}>
+              <Leagues />
+            </Route>
 
-          {/* Render page for /league/{id} - a page for specific league} */}
-          <Route path={`${url}/league/:id`}>
-            <LeagueDetail />
-          </Route>
+            {/* Render page for /league/{id} - a page for specific league} */}
+            <Route path={`${url}/league/:id`}>
+              <LeagueDetail />
+            </Route>
 
-          <Route path={`${url}/gallery`}>
-            <Galleries />
-          </Route>
+            <Route path={`${url}/gallery`}>
+              <Galleries />
+            </Route>
 
-          {/* Render page for /teams */}
-          <Route exact path={`${url}/clubs`}>
-            <Teams />
-          </Route>
+            {/* Render page for /teams */}
+            <Route exact path={`${url}/clubs`}>
+              <Teams />
+            </Route>
 
-          <Route path={`${url}/announcement`}>
-            <Announcements />
-          </Route>
+            <Route path={`${url}/announcement`}>
+              <Announcements />
+            </Route>
 
-          {/* Render page for /team/{id} - a page for
+            {/* Render page for /team/{id} - a page for
            specific team} */}
-          <Route path={`${url}/clubs/:id`}>
-            <TeamDetail />
-          </Route>
+            <Route path={`${url}/clubs/:id`}>
+              <TeamDetail />
+            </Route>
+          </>
         </Switch>
       </main>
     </div>

--- a/client/src/components/league_schedule/LeagueSchedule.tsx
+++ b/client/src/components/league_schedule/LeagueSchedule.tsx
@@ -191,15 +191,15 @@ const UnstyledLeagueSchedule: FunctionComponent<LeagueScheduleProps> = ({
                       }
                       tableRowData={generateScheduleData(match, isMobile)}
                       paperShadow={0}
-                      hideHeader='VS'
-                      standingTableClassName='league-schedule-table-box'
+                      hideHeader="VS"
+                      standingTableClassName="league-schedule-table-box"
                       headerClassName={
                         isMobile
                           ? 'league-schedule-table-mobile-header'
                           : 'league-schedule-table-header'
                       }
-                      rowContentClassName='league-schedule-row-content'
-                      dividerClassName='league-schedule-divider'
+                      rowContentClassName="league-schedule-row-content"
+                      dividerClassName="league-schedule-divider"
                       flex={isMobile ? [2, 2, 2] : [2, 2, 2, 4, 4]}
                     />
                   </Box>

--- a/client/src/components/navigation/components/TeamsNav.tsx
+++ b/client/src/components/navigation/components/TeamsNav.tsx
@@ -115,13 +115,13 @@ export const TeamsNav: React.FC = () => {
         onClose={handleClose}
       >
         {isEmpty(viewer.leagueTeamGroupAge) && (
-          <>
+          <Box>
             <Divider />
             <Box textAlign="center" className="boldText" px={2}>
               Coming soon
             </Box>
             <Divider />
-          </>
+          </Box>
         )}
 
         {map(viewer?.leagueTeamGroupAge, (leagueTeams, key) => {

--- a/client/src/components/schedules/components/schedule_card/ScheduleCard.tsx
+++ b/client/src/components/schedules/components/schedule_card/ScheduleCard.tsx
@@ -18,6 +18,7 @@ interface ScheduleCardProps {
   noHover?: boolean;
   status?: string;
   mobileWidth?: boolean;
+  pastGame?: boolean;
 }
 
 /**
@@ -31,78 +32,79 @@ const UnstyledScheduledCard: FunctionComponent<ScheduleCardProps> = ({
   className,
   noHover,
   status,
-}) => {
-  return (
-    <motion.div whileHover={{ scale: noHover ? 1 : 1.08 }}>
-      <Box mr={6} borderRadius={8} className={className}>
-        <Paper elevation={3}>
-          <Box px={4} py={2} className="text-sub">
-            <Box>{dayjs(date).format('hh:mm A M.DD.YYYY ddd')}</Box>
+}) => (
+  <motion.div whileHover={{ scale: noHover ? 1 : 1.08 }}>
+    <Box mr={6} borderRadius={8} className={className}>
+      <Paper elevation={3}>
+        <Box px={4} py={2} className="text-sub">
+          <Box>{dayjs(date).format('hh:mm A M.DD.YYYY ddd')}</Box>
 
-            <Box>{location}</Box>
+          <Box>{location}</Box>
 
-            <Box
-              mt={1.125}
-              display="flex"
-              justifyContent="start"
-              alignItems="center"
-            >
-              {/* Home team emblem and name */}
-              <Box display="flex" flexDirection="column" alignItems="center">
-                <Box width={80} minHeight={40}>
-                  <img
-                    src={homeTeam.team.teamLogoURL || LogoGrey}
-                    alt="home team logo"
-                  />
-                </Box>
-                <Box>{homeTeam.team.name.toUpperCase()}</Box>
+          <Box
+            mt={1.125}
+            display="flex"
+            justifyContent="start"
+            alignItems="center"
+          >
+            {/* Home team emblem and name */}
+            <Box display="flex" flexDirection="column" alignItems="center">
+              <Box width={80} minHeight={40}>
+                <img
+                  src={homeTeam.team.teamLogoURL || LogoGrey}
+                  alt="home team logo"
+                />
               </Box>
+              <Box>{homeTeam.team.name.toUpperCase()}</Box>
+            </Box>
 
-              <Box ml="auto">
-                {status === 'COMPLETE' ? (
-                  <Box>
-                    <Box display="inline" pr={2} fontSize={22}>
-                      {homeTeam.goalScored}
-                    </Box>
-
-                    <span> vs </span>
-
-                    <Box display="inline" pl={2} fontSize={22}>
-                      {awayTeam.goalScored}
-                    </Box>
+            <Box ml="auto">
+              {status === 'COMPLETE' ? (
+                <Box>
+                  <Box display="inline" pr={2} fontSize={22}>
+                    {homeTeam.goalScored}
                   </Box>
-                ) : (
-                  'vs'
-                )}
-              </Box>
 
-              {/* Away team emblem and name */}
-              <Box
-                display="flex"
-                flexDirection="column"
-                alignItems="center"
-                ml="auto"
-              >
-                <Box width={80} minHeight={40}>
-                  <img
-                    src={awayTeam.team.teamLogoURL || LogoGrey}
-                    alt="away team logo"
-                  />
+                  <span> vs </span>
+
+                  <Box display="inline" pl={2} fontSize={22}>
+                    {awayTeam.goalScored}
+                  </Box>
                 </Box>
-                <Box>{awayTeam.team.name.toUpperCase()}</Box>
+              ) : (
+                'vs'
+              )}
+            </Box>
+
+            {/* Away team emblem and name */}
+            <Box
+              display="flex"
+              flexDirection="column"
+              alignItems="center"
+              ml="auto"
+            >
+              <Box width={80} minHeight={40}>
+                <img
+                  src={awayTeam.team.teamLogoURL || LogoGrey}
+                  alt="away team logo"
+                />
               </Box>
+              <Box>{awayTeam.team.name.toUpperCase()}</Box>
             </Box>
           </Box>
-        </Paper>
-      </Box>
-    </motion.div>
-  );
-};
+        </Box>
+      </Paper>
+    </Box>
+  </motion.div>
+);
 
 export const ScheduleCard = withTheme(styled(UnstyledScheduledCard)`
-  min-width: ${({ mobileWidth }) => (mobileWidth ? '100%' : '332px')};
+  min-width: 332px;
   cursor: pointer;
 
+  .MuiPaper-root {
+    background-color: ${({ pastGame }) => (pastGame ? '#eeeeee' : 'white')};
+  }
   .text-sub {
     font-size: 0.875rem;
     font-weight: 700;

--- a/client/src/components/schedules/components/schedule_card/ScheduleDefaultCard.tsx
+++ b/client/src/components/schedules/components/schedule_card/ScheduleDefaultCard.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 
 interface ScheduleCardProps {
   className?: string;
-  idx?: number;
 }
 
 /**
@@ -13,36 +12,25 @@ interface ScheduleCardProps {
  */
 const UnstyledScheduleDefaultCard: FunctionComponent<ScheduleCardProps> = ({
   className,
-  idx,
-}) => {
-  return (
-    <Box mr={6} borderRadius={8} className={className}>
-      <Box
-        fontSize={16}
-        color="white"
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        className="center"
-      >
-        <Box>No Match Schedule {idx}</Box>
-      </Box>
+}) => (
+  <Box mr={6} borderRadius={8} className={className}>
+    <Box
+      fontSize={16}
+      color="white"
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      height={'100%'}
+    >
+      No Match Schedule
     </Box>
-  );
-};
+  </Box>
+);
 
 export const ScheduleDefaultCard = withTheme(styled(
   UnstyledScheduleDefaultCard
 )`
   min-width: 332px;
-  min-height: 200px;
+  height: 200px;
   background: #c4c4c4;
-
-  .center {
-    position: relative;
-    top: 50%;
-    -webkit-transform: translateY(-50%);
-    -ms-transform: translateY(-50%);
-    transform: translateY(-50%);
-  }
 `);


### PR DESCRIPTION
Before: 
- Matches are NOT sorted, All matches are shown(not within 2. weeks) 
- Alignments were allover the place.
https://user-images.githubusercontent.com/6810688/141673295-ed708773-30db-421f-9693-b0a807e0bf7a.mp4


After:
1. Matches shown are filtered within 2weeks frame
2. Alignment with headers (League age Types: OPEN, and `NExt match schedule`) matches,
3. Past games are automatically 'scrolled' so users sees the upcoming matches right away. 
https://user-images.githubusercontent.com/6810688/141673236-5f315830-ae1a-433e-ab63-94c756204e46.mp4

ㅆ... 이거 고치는건 진짜 개빡셋다..